### PR TITLE
fix: Ignore starting position in findInterestingPosition

### DIFF
--- a/backend/tasks.ts
+++ b/backend/tasks.ts
@@ -47,6 +47,11 @@ function findInterestingPositions(code: string): Position[] {
   
   lines.forEach((line, lineIndex) => {
     for (let col = 0; col < line.length; col++) {
+      if (lineIndex === 0 && col === 0) {
+        // this is player's starting position, so we skip it
+        continue;
+      }
+      
       const char = line[col];
       if (char !== ' ' && char !== '\t') {
         positions.push({ line: lineIndex + 1, col });


### PR DESCRIPTION
When game starts, sometimes the game chooses the first line and first column as the position to get to, which doesn't make sense